### PR TITLE
5 December R1

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -236,7 +236,7 @@ func handleIncoming(e *endPoint) func(http.ResponseWriter, *http.Request) {
 		//TODO: capture this using instrumentation handler
 
 		var body interface{}
-		logActivity := conf.Bool("log_activity", false)
+		logActivity := conf.Bool("log_activity", false) && e.info.Log
 		if logActivity == true {
 			r.Body, body = copyReqBody(r.Body)
 		}

--- a/endpoint.go
+++ b/endpoint.go
@@ -273,7 +273,7 @@ func handleIncoming(e *endPoint) func(http.ResponseWriter, *http.Request) {
 						response = out[0].Interface()
 					}
 				}
-				activity.LogActivity(r.RequestURI+" "+e.serviceId, body, response,
+				activity.LogActivity(r.RequestURI, e.serviceId, body, response,
 					int(responseCode), respTime)
 			}
 			//User Activity logger end

--- a/fixture.go
+++ b/fixture.go
@@ -2,6 +2,7 @@ package aqua
 
 import (
 	"reflect"
+	"strconv"
 )
 
 type Fixture struct {
@@ -17,6 +18,7 @@ type Fixture struct {
 	Cache string // cache store
 	Ttl   string // cache ttl
 	Auth  string // authentication method
+	Log   bool
 }
 
 func NewFixtureFromTag(i interface{}, fieldName string) Fixture {
@@ -69,6 +71,11 @@ func NewFixtureFromTag(i interface{}, fieldName string) Fixture {
 	tmp = getTagValue(tag, "ttl")
 	if tmp != "" {
 		out.Ttl = tmp
+	}
+
+	tmp = getTagValue(tag, "log")
+	if tmp != "" {
+		out.Log, _ = strconv.ParseBool(tmp)
 	}
 
 	tmp = getTagValue(tag, "stub")
@@ -125,6 +132,9 @@ func resolveInOrder(e ...Fixture) Fixture {
 		}
 		if out.Ttl == empty && ep.Ttl != empty {
 			out.Ttl = ep.Ttl
+		}
+		if out.Log == false && ep.Log == true {
+			out.Log = ep.Log
 		}
 		if out.Stub == empty && ep.Stub != empty {
 			out.Stub = ep.Stub

--- a/rest_server.go
+++ b/rest_server.go
@@ -20,6 +20,7 @@ var defaults Fixture = Fixture{
 	Cache:   "",
 	Ttl:     "",
 	Auth:    "",
+	Log:     false,
 }
 
 var release string = "0.0.1"


### PR DESCRIPTION
PRA-RESTORE - Tally Sync Restore
PRA-655 - Update Phone no data validation
PRA-663 - Address update for adding & update
PRA-606 - LR, Invoice, Challan Filter
PRA-410A - Capture User Activity for log tag only
PRA-105I - Tally Updates
PRA-25-PRA-606 - show warehouse and a warehouse filter drop down option on screen 3
PRA-25-PRA-606 - As a Poora Seller/Seller User, I should be able to filter packs basis on Challan/Invoice is generated/not generated/all on In-Packing screen
PRA-25-PRA-606 - As a Poora Seller/Seller User, I should be able to filter packs basis on Challan/Invoice is generated/not generated/all on In-Packing screen
PRA-649 - Add tally Status in listing product
PRA-658 - Update Search of customer
PRA-662 - Disable Product
PRA-651 - Tally Bug -On click of "Map to customers" there is no Close button to close that expanded view.